### PR TITLE
Use `currentColor` for fill

### DIFF
--- a/buildTools/src/component_builder.ts
+++ b/buildTools/src/component_builder.ts
@@ -9,7 +9,7 @@ export function buildComponent(iconSVG: string): string {
 <template>
     ${iconSVG.replace(
       /<svg([^>]+)>/,
-      '<svg :width="finalSize" :height="finalSize" role="img" viewBox="0 0 24 24" v-bind="$attrs" >'
+      '<svg :width="finalSize" :height="finalSize" role="img" viewBox="0 0 24 24" v-bind="$attrs" fill="currentColor">'
     )}
 </template>
 ${componentScript}`;


### PR DESCRIPTION
Hi, I'm using this library with [nuxt-lucide-icons](https://github.com/swisnl/nuxt-lucide-icons) which adds `stroke="currentColor"` to the svg. This way, icons can be recolored in css by setting the `color` property of the svg. Right now the only way to change the color of an icon is in the markup, so I think setting `fill="currentColor"` would be really useful to allow this to be changed in CSS as well as generally following the current text color as a reasonable fallback